### PR TITLE
Fix reset screen issue when rotate device

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/HomeScreen.kt
@@ -1,10 +1,13 @@
 package jp.co.yumemi.android.code_check.feature.home
 
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import jp.co.yumemi.android.code_check.core.model.GhRepositoryName
 import jp.co.yumemi.android.code_check.core.ui.theme.LocalWindowWidthSize
@@ -23,10 +26,15 @@ fun HomeScreen(
     navigateToAboutApp: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val navController = rememberNavController()
+
     when (LocalWindowWidthSize.current) {
         WindowWidthSizeClass.Compact -> {
             HomeCompactScreen(
                 modifier = modifier,
+                drawerState = drawerState,
+                navController = navController,
                 navigateToRepositoryDetail = navigateToRepositoryDetail,
                 navigateToSettingTop = navigateToSettingTop,
                 navigateToAboutApp = navigateToAboutApp,
@@ -36,6 +44,8 @@ fun HomeScreen(
         WindowWidthSizeClass.Medium -> {
             HomeMediumScreen(
                 modifier = modifier,
+                drawerState = drawerState,
+                navController = navController,
                 navigateToRepositoryDetail = navigateToRepositoryDetail,
                 navigateToSettingTop = navigateToSettingTop,
                 navigateToAboutApp = navigateToAboutApp,
@@ -45,6 +55,8 @@ fun HomeScreen(
         WindowWidthSizeClass.Expanded -> {
             HomeExpandedScreen(
                 modifier = modifier,
+                drawerState = drawerState,
+                navController = navController,
                 navigateToRepositoryDetail = navigateToRepositoryDetail,
                 navigateToSettingTop = navigateToSettingTop,
                 navigateToAboutApp = navigateToAboutApp,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/components/HomeCompactScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/components/HomeCompactScreen.kt
@@ -3,14 +3,13 @@ package jp.co.yumemi.android.code_check.feature.home.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.DrawerState
 import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
 import jp.co.yumemi.android.code_check.core.model.GhRepositoryName
 import jp.co.yumemi.android.code_check.feature.home.HomeNavHost
 import jp.co.yumemi.android.code_check.feature.home.navigateToHomeDestination
@@ -20,14 +19,14 @@ import org.koin.compose.koinInject
 
 @Composable
 fun HomeCompactScreen(
+    drawerState: DrawerState,
+    navController: NavHostController,
     navigateToRepositoryDetail: (GhRepositoryName) -> Unit,
     navigateToSettingTop: () -> Unit,
     navigateToAboutApp: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val navController = rememberNavController()
 
     ModalNavigationDrawer(
         modifier = modifier,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/components/HomeExpandedScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/components/HomeExpandedScreen.kt
@@ -3,14 +3,13 @@ package jp.co.yumemi.android.code_check.feature.home.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.DrawerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PermanentNavigationDrawer
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
 import jp.co.yumemi.android.code_check.core.model.GhRepositoryName
 import jp.co.yumemi.android.code_check.feature.home.HomeNavHost
 import jp.co.yumemi.android.code_check.feature.home.navigateToHomeDestination
@@ -18,14 +17,13 @@ import org.koin.compose.koinInject
 
 @Composable
 fun HomeExpandedScreen(
+    drawerState: DrawerState,
+    navController: NavHostController,
     navigateToRepositoryDetail: (GhRepositoryName) -> Unit,
     navigateToSettingTop: () -> Unit,
     navigateToAboutApp: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val navController = rememberNavController()
-
     PermanentNavigationDrawer(
         modifier = modifier,
         drawerContent = {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/components/HomeMediumScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/home/components/HomeMediumScreen.kt
@@ -2,14 +2,13 @@ package jp.co.yumemi.android.code_check.feature.home.components
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.DrawerState
 import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
 import jp.co.yumemi.android.code_check.core.model.GhRepositoryName
 import jp.co.yumemi.android.code_check.feature.home.HomeNavHost
 import jp.co.yumemi.android.code_check.feature.home.navigateToHomeDestination
@@ -19,14 +18,14 @@ import org.koin.compose.koinInject
 
 @Composable
 fun HomeMediumScreen(
+    drawerState: DrawerState,
+    navController: NavHostController,
     navigateToRepositoryDetail: (GhRepositoryName) -> Unit,
     navigateToSettingTop: () -> Unit,
     navigateToAboutApp: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val navController = rememberNavController()
 
     ModalNavigationDrawer(
         modifier = modifier,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Application
-versionName = "1.0.3"
-versionCode = "4"
+versionName = "1.0.4"
+versionCode = "5"
 
 # SDK
 minSdk = "23"


### PR DESCRIPTION
# Related links
- N/A

# How?
- 画面回転により `WindowWidthSizeClass` の値が変わると `navHostController` が新規作成されるため状態が保持されなくなる問題を修正しました
- バージョンを 1.0.4 に上げました